### PR TITLE
add 'mixed' type

### DIFF
--- a/tableshape/init.lua
+++ b/tableshape/init.lua
@@ -1,6 +1,5 @@
 local BaseType
 do
-  local _class_0
   local _base_0 = {
     check_value = function(self)
       return error("override me")
@@ -44,7 +43,7 @@ do
     end
   }
   _base_0.__index = _base_0
-  _class_0 = setmetatable({
+  local _class_0 = setmetatable({
     __init = function() end,
     __base = _base_0,
     __name = "BaseType"
@@ -78,7 +77,6 @@ do
 end
 local AnyType
 do
-  local _class_0
   local _parent_0 = BaseType
   local _base_0 = {
     check_value = function(self)
@@ -90,9 +88,9 @@ do
   }
   _base_0.__index = _base_0
   setmetatable(_base_0, _parent_0.__base)
-  _class_0 = setmetatable({
+  local _class_0 = setmetatable({
     __init = function(self, ...)
-      return _class_0.__parent.__init(self, ...)
+      return _parent_0.__init(self, ...)
     end,
     __base = _base_0,
     __name = "AnyType",
@@ -101,10 +99,7 @@ do
     __index = function(cls, name)
       local val = rawget(_base_0, name)
       if val == nil then
-        local parent = rawget(cls, "__parent")
-        if parent then
-          return parent[name]
-        end
+        return _parent_0[name]
       else
         return val
       end
@@ -123,7 +118,6 @@ do
 end
 local Type
 do
-  local _class_0
   local _parent_0 = BaseType
   local _base_0 = {
     is_optional = function(self)
@@ -152,7 +146,7 @@ do
   }
   _base_0.__index = _base_0
   setmetatable(_base_0, _parent_0.__base)
-  _class_0 = setmetatable({
+  local _class_0 = setmetatable({
     __init = function(self, t, opts)
       self.t, self.opts = t, opts
     end,
@@ -163,10 +157,7 @@ do
     __index = function(cls, name)
       local val = rawget(_base_0, name)
       if val == nil then
-        local parent = rawget(cls, "__parent")
-        if parent then
-          return parent[name]
-        end
+        return _parent_0[name]
       else
         return val
       end
@@ -185,7 +176,6 @@ do
 end
 local ArrayType
 do
-  local _class_0
   local _parent_0 = BaseType
   local _base_0 = {
     is_optional = function(self)
@@ -220,7 +210,7 @@ do
   }
   _base_0.__index = _base_0
   setmetatable(_base_0, _parent_0.__base)
-  _class_0 = setmetatable({
+  local _class_0 = setmetatable({
     __init = function(self, opts)
       self.opts = opts
     end,
@@ -231,10 +221,7 @@ do
     __index = function(cls, name)
       local val = rawget(_base_0, name)
       if val == nil then
-        local parent = rawget(cls, "__parent")
-        if parent then
-          return parent[name]
-        end
+        return _parent_0[name]
       else
         return val
       end
@@ -253,7 +240,6 @@ do
 end
 local OneOf
 do
-  local _class_0
   local _parent_0 = BaseType
   local _base_0 = {
     is_optional = function(self)
@@ -304,7 +290,7 @@ do
   }
   _base_0.__index = _base_0
   setmetatable(_base_0, _parent_0.__base)
-  _class_0 = setmetatable({
+  local _class_0 = setmetatable({
     __init = function(self, items, opts)
       self.items, self.opts = items, opts
       return assert(type(self.items) == "table", "expected table for items in one_of")
@@ -316,10 +302,7 @@ do
     __index = function(cls, name)
       local val = rawget(_base_0, name)
       if val == nil then
-        local parent = rawget(cls, "__parent")
-        if parent then
-          return parent[name]
-        end
+        return _parent_0[name]
       else
         return val
       end
@@ -338,7 +321,6 @@ do
 end
 local ArrayOf
 do
-  local _class_0
   local _parent_0 = BaseType
   local _base_0 = {
     is_optional = function(self)
@@ -447,7 +429,7 @@ do
   }
   _base_0.__index = _base_0
   setmetatable(_base_0, _parent_0.__base)
-  _class_0 = setmetatable({
+  local _class_0 = setmetatable({
     __init = function(self, expected, opts)
       self.expected, self.opts = expected, opts
     end,
@@ -458,10 +440,7 @@ do
     __index = function(cls, name)
       local val = rawget(_base_0, name)
       if val == nil then
-        local parent = rawget(cls, "__parent")
-        if parent then
-          return parent[name]
-        end
+        return _parent_0[name]
       else
         return val
       end
@@ -482,7 +461,6 @@ do
 end
 local MapOf
 do
-  local _class_0
   local _parent_0 = BaseType
   local _base_0 = {
     is_optional = function(self)
@@ -529,7 +507,7 @@ do
   }
   _base_0.__index = _base_0
   setmetatable(_base_0, _parent_0.__base)
-  _class_0 = setmetatable({
+  local _class_0 = setmetatable({
     __init = function(self, expected_key, expected_value, opts)
       self.expected_key, self.expected_value, self.opts = expected_key, expected_value, opts
     end,
@@ -540,10 +518,7 @@ do
     __index = function(cls, name)
       local val = rawget(_base_0, name)
       if val == nil then
-        local parent = rawget(cls, "__parent")
-        if parent then
-          return parent[name]
-        end
+        return _parent_0[name]
       else
         return val
       end
@@ -562,7 +537,6 @@ do
 end
 local Shape
 do
-  local _class_0
   local _parent_0 = BaseType
   local _base_0 = {
     is_optional = function(self)
@@ -707,7 +681,7 @@ do
   }
   _base_0.__index = _base_0
   setmetatable(_base_0, _parent_0.__base)
-  _class_0 = setmetatable({
+  local _class_0 = setmetatable({
     __init = function(self, shape, opts)
       self.shape, self.opts = shape, opts
       return assert(type(self.shape) == "table", "expected table for shape")
@@ -719,10 +693,7 @@ do
     __index = function(cls, name)
       local val = rawget(_base_0, name)
       if val == nil then
-        local parent = rawget(cls, "__parent")
-        if parent then
-          return parent[name]
-        end
+        return _parent_0[name]
       else
         return val
       end
@@ -741,9 +712,93 @@ do
   end
   Shape = _class_0
 end
+local Mixed
+do
+  local _parent_0 = Shape
+  local _base_0 = {
+    check_value = function(self, value)
+      if self:check_optional(value) then
+        return true
+      end
+      if not (type(value) == "table") then
+        return nil, self.__class.type_err_message
+      end
+      local remaining_keys
+      if not (self.opts and self.opts.open) then
+        do
+          local _tbl_0 = { }
+          for key in pairs(value) do
+            _tbl_0[key] = true
+          end
+          remaining_keys = _tbl_0
+        end
+      end
+      for shape_key, shape_val in pairs(self.shape) do
+        if type(shape_key) == "number" and not self.shape[shape_key + 1] then
+          for shape_key = shape_key, #value do
+            local item_value = value[shape_key]
+            if remaining_keys then
+              remaining_keys[shape_key] = nil
+            end
+            local pass, err = self:check_field(shape_key, item_value, shape_val, value)
+            if not (pass) then
+              return nil, err
+            end
+          end
+        else
+          local item_value = value[shape_key]
+          if remaining_keys then
+            remaining_keys[shape_key] = nil
+          end
+          local pass, err = self:check_field(shape_key, item_value, shape_val, value)
+          if not (pass) then
+            return nil, err
+          end
+        end
+      end
+      if remaining_keys then
+        do
+          local extra_key = next(remaining_keys)
+          if extra_key then
+            return nil, "has extra field: `" .. tostring(extra_key) .. "`"
+          end
+        end
+      end
+      return true
+    end
+  }
+  _base_0.__index = _base_0
+  setmetatable(_base_0, _parent_0.__base)
+  local _class_0 = setmetatable({
+    __init = function(self, ...)
+      return _parent_0.__init(self, ...)
+    end,
+    __base = _base_0,
+    __name = "Mixed",
+    __parent = _parent_0
+  }, {
+    __index = function(cls, name)
+      local val = rawget(_base_0, name)
+      if val == nil then
+        return _parent_0[name]
+      else
+        return val
+      end
+    end,
+    __call = function(cls, ...)
+      local _self_0 = setmetatable({}, _base_0)
+      cls.__init(_self_0, ...)
+      return _self_0
+    end
+  })
+  _base_0.__class = _class_0
+  if _parent_0.__inherited then
+    _parent_0.__inherited(_parent_0, _class_0)
+  end
+  Mixed = _class_0
+end
 local Pattern
 do
-  local _class_0
   local _parent_0 = BaseType
   local _base_0 = {
     is_optional = function(self)
@@ -786,7 +841,7 @@ do
   }
   _base_0.__index = _base_0
   setmetatable(_base_0, _parent_0.__base)
-  _class_0 = setmetatable({
+  local _class_0 = setmetatable({
     __init = function(self, pattern, opts)
       self.pattern, self.opts = pattern, opts
     end,
@@ -797,10 +852,7 @@ do
     __index = function(cls, name)
       local val = rawget(_base_0, name)
       if val == nil then
-        local parent = rawget(cls, "__parent")
-        if parent then
-          return parent[name]
-        end
+        return _parent_0[name]
       else
         return val
       end
@@ -834,6 +886,7 @@ local types = setmetatable({
   }),
   one_of = OneOf,
   shape = Shape,
+  mixed = Mixed,
   pattern = Pattern,
   array_of = ArrayOf,
   map_of = MapOf


### PR DESCRIPTION
i am not sure how the interface and semantics should look for this, but what I
found to be missing was a way to specify mixed-type tables.

For example I often use tables that are mostly arrays of a fixed 'shape' but
have extra fields with meta keys:

```
changes =
  origin: "user",
  { "changeset 1" },
  { "changeset 2" },
  { "changeset 3" }
```

If I didn't miss something in the README, I don't think its possible to specify a shape like that accurately (only by setting the rest and then making it `open`).

My implementation takes the highest integer key and applies it's shape to all following keys.

I didn't add any tests because I'm pretty sure you want a more clear interface anyway.